### PR TITLE
Use settings values to generate branch names

### DIFF
--- a/entrypoints/options/BranchTemplateSettings.tsx
+++ b/entrypoints/options/BranchTemplateSettings.tsx
@@ -25,7 +25,7 @@ import { type FormData } from "./OptionsPage"
 type BranchTemplatesSettingsProps = {
   control: Control<FormData>
   watchTemplates: Template[]
-  watchDefaultTemplate: string
+  watchDefaultTemplateId: string
   newTemplate: { name: string; template: string }
   setNewTemplate: Dispatch<SetStateAction<{ name: string; template: string }>>
   getValues: UseFormGetValues<FormData>
@@ -34,7 +34,7 @@ type BranchTemplatesSettingsProps = {
 
 const BranchTemplatesSettings: FC<BranchTemplatesSettingsProps> = ({
   watchTemplates,
-  watchDefaultTemplate,
+  watchDefaultTemplateId,
   newTemplate,
   setNewTemplate,
   getValues,
@@ -61,8 +61,8 @@ const BranchTemplatesSettings: FC<BranchTemplatesSettingsProps> = ({
     setValue("templates", filteredTemplates as NonEmptyTemplateArray)
 
     // If the default template is removed, set a new default
-    if (getValues("defaultTemplate") === id && templates.length > 1) {
-      setValue("defaultTemplate", filteredTemplates[0].id)
+    if (getValues("defaultTemplateId") === id && templates.length > 1) {
+      setValue("defaultTemplateId", filteredTemplates[0].id)
     }
   }
 
@@ -92,12 +92,12 @@ const BranchTemplatesSettings: FC<BranchTemplatesSettingsProps> = ({
                   <Button
                     type="button"
                     variant={
-                      watchDefaultTemplate === template.id ? "secondary" : "outline"
+                      watchDefaultTemplateId === template.id ? "secondary" : "outline"
                     }
                     size="sm"
                     className="h-8"
-                    onClick={() => setValue("defaultTemplate", template.id)}>
-                    {watchDefaultTemplate === template.id && (
+                    onClick={() => setValue("defaultTemplateId", template.id)}>
+                    {watchDefaultTemplateId === template.id && (
                       <Check className="h-4 w-4 mr-1" />
                     )}
                     Default

--- a/entrypoints/options/CategoriesOptions.tsx
+++ b/entrypoints/options/CategoriesOptions.tsx
@@ -13,7 +13,7 @@ import { type FormData } from "./OptionsPage"
 
 type CategoriesSettingsProps = {
   watchCategories: Category[]
-  watchDefaultCategory: string
+  watchDefaultCategoryId: string
   newCategory: string
   setNewCategory: Dispatch<SetStateAction<string>>
   getValues: UseFormGetValues<FormData>
@@ -22,7 +22,7 @@ type CategoriesSettingsProps = {
 
 const CategoriesSettings: FC<CategoriesSettingsProps> = ({
   watchCategories,
-  watchDefaultCategory,
+  watchDefaultCategoryId,
   newCategory,
   setNewCategory,
   getValues,
@@ -46,8 +46,8 @@ const CategoriesSettings: FC<CategoriesSettingsProps> = ({
     setValue("categories", filteredCategories as NonEmptyCategoryArray)
 
     // If the default category is removed, set a new default
-    if (getValues("defaultCategory") === id && categories.length > 1) {
-      setValue("defaultCategory", filteredCategories[0].id)
+    if (getValues("defaultCategoryId") === id && categories.length > 1) {
+      setValue("defaultCategoryId", filteredCategories[0].id)
     }
   }
 
@@ -71,12 +71,12 @@ const CategoriesSettings: FC<CategoriesSettingsProps> = ({
                 <Button
                   type="button"
                   variant={
-                    watchDefaultCategory === category.id ? "secondary" : "outline"
+                    watchDefaultCategoryId === category.id ? "secondary" : "outline"
                   }
                   size="sm"
                   className="h-7 px-2"
-                  onClick={() => setValue("defaultCategory", category.id)}>
-                  {watchDefaultCategory === category.id && (
+                  onClick={() => setValue("defaultCategoryId", category.id)}>
+                  {watchDefaultCategoryId === category.id && (
                     <Check className="h-3 w-3 mr-1" />
                   )}
                   Default

--- a/entrypoints/options/OptionsPage.tsx
+++ b/entrypoints/options/OptionsPage.tsx
@@ -88,7 +88,7 @@ export const formSchema = z.object({
         ]
       }
     ),
-  defaultTemplate: z.string(),
+  defaultTemplateId: z.string(),
   categories: z
     .array(
       z.object({
@@ -115,7 +115,7 @@ export const formSchema = z.object({
         return val as [{ id: string; name: string }, ...{ id: string; name: string }[]]
       }
     ),
-  defaultCategory: z.string(),
+  defaultCategoryId: z.string(),
   enforceLowercase: z.boolean(),
   replacementCharacter: z
     .string()
@@ -166,18 +166,20 @@ const OptionsPage = () => {
   }, [])
 
   const watchTemplates = form.watch("templates")
-  const watchDefaultTemplate = form.watch("defaultTemplate")
+  const watchDefaultTemplateId = form.watch("defaultTemplateId")
   const watchCategories = form.watch("categories")
-  const watchDefaultCategory = form.watch("defaultCategory")
+  const watchDefaultCategoryId = form.watch("defaultCategoryId")
   const watchEnforceLowercase = form.watch("enforceLowercase")
   const watchReplacementCharacter = form.watch("replacementCharacter")
   const watchUsername = form.watch("username")
 
   const generatePreview = () => {
-    const selectedTemplate = watchTemplates.find((t) => t.id === watchDefaultTemplate)
+    const selectedTemplate = watchTemplates.find((t) => t.id === watchDefaultTemplateId)
     if (!selectedTemplate) return ""
 
-    const selectedCategory = watchCategories.find((c) => c.id === watchDefaultCategory)
+    const selectedCategory = watchCategories.find(
+      (c) => c.id === watchDefaultCategoryId
+    )
     const categoryName = selectedCategory ? selectedCategory.name : previewData.category
 
     try {
@@ -306,7 +308,7 @@ const OptionsPage = () => {
               <BranchTemplateSettings
                 control={form.control}
                 watchTemplates={watchTemplates}
-                watchDefaultTemplate={watchDefaultTemplate}
+                watchDefaultTemplateId={watchDefaultTemplateId}
                 newTemplate={newTemplate}
                 setNewTemplate={setNewTemplate}
                 getValues={form.getValues}
@@ -318,7 +320,7 @@ const OptionsPage = () => {
             <TabsContent value="categories">
               <CategoriesOptions
                 watchCategories={watchCategories}
-                watchDefaultCategory={watchDefaultCategory}
+                watchDefaultCategoryId={watchDefaultCategoryId}
                 newCategory={newCategory}
                 setNewCategory={setNewCategory}
                 getValues={form.getValues}

--- a/entrypoints/popup/Popup.tsx
+++ b/entrypoints/popup/Popup.tsx
@@ -7,9 +7,11 @@ import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import Icons from "@/entrypoints/popup/Icons"
 import { generateBranchName } from "@/lib/branch-name-generator"
+import { getSettingsStorageService } from "@/lib/settings-storage-service"
 import { getTicketProvidersService } from "@/lib/ticket-providers-service"
 
 const ticketProvidersService = getTicketProvidersService()
+const settingsStorageService = getSettingsStorageService()
 
 const Popup = () => {
   const [copied, setCopied] = React.useState(false)
@@ -23,11 +25,15 @@ const Popup = () => {
         const url = tab.url ?? tab.pendingUrl
         const isSupported = await ticketProvidersService.isSupported(url ?? "")
         if (isSupported) {
+          const settings = await settingsStorageService.get()
           const ticketInfo = await ticketProvidersService.parseUrl(url ?? "")
+          const template = settings.templates.find(
+            (t) => t.id === settings.defaultTemplateId
+          )
           const name = generateBranchName(
-            "{username}/{id}-{title}",
+            template!.template,
             ticketInfo,
-            "farmisen"
+            settings.username
           )
           setBranchName(name)
         }
@@ -50,7 +56,7 @@ const Popup = () => {
   const copyToClipboard = async () => {
     await navigator.clipboard.writeText(branchName)
     setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    setTimeout(() => window.close(), 2000)
   }
 
   return (

--- a/entrypoints/popup/Popup.tsx
+++ b/entrypoints/popup/Popup.tsx
@@ -30,8 +30,13 @@ const Popup = () => {
           const template = settings.templates.find(
             (t) => t.id === settings.defaultTemplateId
           )
+
+          if (!template) {
+            throw new Error(`Template #${settings.defaultTemplateId} not found`)
+          }
+
           const name = generateBranchName(
-            template!.template,
+            template.template,
             ticketInfo,
             settings.username
           )

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SETTINGS: Settings = {
       template: "{username}/{category}/{id}-{title}"
     }
   ],
-  defaultTemplate: "1",
+  defaultTemplateId: "1",
   categories: [
     { id: "1", name: "feat" },
     { id: "2", name: "bug" },
@@ -20,7 +20,7 @@ export const DEFAULT_SETTINGS: Settings = {
     { id: "5", name: "refactor" },
     { id: "6", name: "test" }
   ],
-  defaultCategory: "1",
+  defaultCategoryId: "1",
   enforceLowercase: true,
   replacementCharacter: "-"
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,9 +38,9 @@ export type NonEmptyTemplateArray = [Template, ...Template[]]
 export type Settings = {
   username: string
   templates: NonEmptyTemplateArray
-  defaultTemplate: string
+  defaultTemplateId: string
   categories: NonEmptyCategoryArray
-  defaultCategory: string
+  defaultCategoryId: string
   enforceLowercase: boolean
   replacementCharacter: string
 }


### PR DESCRIPTION
The main functional enhancement is in the Popup.tsx file, where the branch name generation now uses the user's settings from storage instead of hardcoded values:
- Adds the settings storage service to retrieve user preferences
- Uses the default template from settings instead of a hardcoded template string
- Uses the username from settings instead of a hardcoded username
- Changes the behavior after copying to clipboard to close the popup window after 2 seconds instead of just resetting the copied state

This change also renames several settings fields to be more explicit about their purpose:
- `defaultTemplate` → `defaultTemplateId`
- `defaultCategory` → `defaultCategoryId`


All references to these renamed fields are updated throughout the codebase to maintain consistency, including in form validation schemas, component props, and default settings constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized the naming for default template and category settings to enhance clarity and consistency across the application.
  
- **New Features**
  - Improved branch name generation by dynamically using stored user settings, with an updated copy action that now automatically closes the window after use for a smoother workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->