### PR TITLE
Fix branch name generation when ticket category is missing

### DIFF
--- a/entrypoints/options/OptionsPage.tsx
+++ b/entrypoints/options/OptionsPage.tsx
@@ -193,6 +193,7 @@ const OptionsPage = () => {
         watchUsername && watchUsername.length > 0
           ? watchUsername
           : previewData.username,
+        categoryName,
         {
           lower: watchEnforceLowercase,
           replacement: watchReplacementCharacter

--- a/entrypoints/popup/Popup.tsx
+++ b/entrypoints/popup/Popup.tsx
@@ -26,6 +26,15 @@ const Popup = () => {
         const isSupported = await ticketProvidersService.isSupported(url ?? "")
         if (isSupported) {
           const settings = await settingsStorageService.get()
+          const defaultCategory = settings.categories.find(
+            (c) => c.id === settings.defaultCategoryId
+          )
+
+          if (!defaultCategory) {
+            console.error(`Category #${settings.defaultCategoryId} not found`)
+            throw new Error(`Category #${settings.defaultCategoryId} not found`)
+          }
+
           const ticketInfo = await ticketProvidersService.parseUrl(url ?? "")
           const template = settings.templates.find(
             (t) => t.id === settings.defaultTemplateId
@@ -38,7 +47,8 @@ const Popup = () => {
           const name = generateBranchName(
             template.template,
             ticketInfo,
-            settings.username
+            settings.username,
+            defaultCategory.name
           )
           setBranchName(name)
         }

--- a/lib/__tests__/branch-name-generator.test.ts
+++ b/lib/__tests__/branch-name-generator.test.ts
@@ -5,6 +5,24 @@ import { type GeneratorOptions, type TicketInfo } from "../types"
 
 describe("generator", () => {
   describe("generate", () => {
+    it("should use default category when ticket has no category", () => {
+      const ticketInfo: TicketInfo = {
+        id: "123",
+        title: "Test Ticket"
+      }
+      const username = "testuser"
+      const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
+
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
+
+      expect(result).toBe("testuser/test/123-test_ticket")
+    })
     it("should replace template variables with corresponding values", () => {
       const ticketInfo: TicketInfo = {
         id: "123",
@@ -13,8 +31,14 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("testuser/feature/123-test_ticket")
     })
@@ -26,8 +50,14 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{id}-{title}"
+      const defaultCategory = "feature"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("testuser/123-")
     })
@@ -38,10 +68,11 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{id}-{title}"
+      const defaultCategory = "feature"
 
-      expect(() => generateBranchName(urlTemplate, ticketInfo, username)).toThrow(
-        "Missing template fields: id"
-      )
+      expect(() =>
+        generateBranchName(urlTemplate, ticketInfo, username, defaultCategory)
+      ).toThrow("Missing template fields: id")
     })
 
     it("should strip out special characters", () => {
@@ -52,8 +83,14 @@ describe("generator", () => {
       }
       const username = "test.user"
       const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("test.user/test/123-special_characters_spaces")
     })
@@ -62,8 +99,14 @@ describe("generator", () => {
       const ticketInfo: TicketInfo = {}
       const username = "testuser"
       const urlTemplate = "{username}/static-path"
+      const defaultCategory = "test"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("testuser/static-path")
     })
@@ -76,8 +119,14 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{category}/{id}-{title}"
+      const defaultCategory = "test"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("feature/123-test_ticket_with_spaces")
     })
@@ -90,12 +139,19 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
       const options: GeneratorOptions = {
         lower: true,
         replacement: "-"
       }
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username, options)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory,
+        options
+      )
 
       expect(result).toBe("testuser/feature/123-test-ticket-with-spaces")
     })
@@ -108,12 +164,19 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
       const options: GeneratorOptions = {
         lower: false,
         replacement: "_"
       }
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username, options)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory,
+        options
+      )
 
       expect(result).toBe("testuser/Feature/123-Test_Ticket")
     })
@@ -126,8 +189,14 @@ describe("generator", () => {
       }
       const username = "testuser"
       const urlTemplate = "{username}/{category}/{id}-{title}"
+      const defaultCategory = "test"
 
-      const result = generateBranchName(urlTemplate, ticketInfo, username)
+      const result = generateBranchName(
+        urlTemplate,
+        ticketInfo,
+        username,
+        defaultCategory
+      )
 
       expect(result).toBe("testuser/feature/123-test_ticket")
     })

--- a/lib/branch-name-generator.ts
+++ b/lib/branch-name-generator.ts
@@ -13,10 +13,11 @@ export const generateBranchName = (
   urlTemplate: string,
   ticketInfo: TicketInfo,
   username: string,
+  category: string,
   options: GeneratorOptions = defaultOptions
 ) => {
   // should error if a template field is missing a value from TicketInfo
-  const { id, title, category } = ticketInfo
+  const { id, title, category: ticketCategory } = ticketInfo
   const info = { id, title, category, username }
   const missing = [] as string[]
 
@@ -42,5 +43,5 @@ export const generateBranchName = (
     .replace("{id}", processField(id))
     .replace("{title}", processField(title))
     .replace("{username}", username) // Username is not processed
-    .replace("{category}", processField(category))
+    .replace("{category}", processField(ticketCategory ?? category))
 }


### PR DESCRIPTION
This change fixes an issue where the branch name generator would fail when a ticket doesn't have a category. The fix:

1. In the Popup component, it now retrieves the default category from settings and passes it to the branch name generator
2. Adds validation to check if the default category exists, throwing an error if not found
3. Modifies the branch name generator to accept a category parameter
4. Updates the generator to use the ticket's category if available, otherwise falls back to the provided default category

This ensures branch names can be generated even when tickets don't include category information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced branch naming functionality to incorporate the selected or default category name, resulting in more descriptive branch names.
  
- **Bug Fixes**
  - Improved error handling to verify the existence of a default category and prevent misconfigurations.
  
- **Tests**
  - Updated test cases to validate the new branch naming logic and ensure consistent behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->