### PR TITLE
Fix icon change not working in Firefox by using browserAction fallback

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -14,7 +14,7 @@ const handleTabChange = async (tabId: number) => {
     const url = tab.url ?? tab.pendingUrl
     const isSupported = ticketProvidersService.isSupported(url ?? "")
     const iconPaths = getIconPaths(isSupported ? IconType.TREE : IconType.TRUNK)
-    await browser.action.setIcon({ path: iconPaths })
+    await (browser.action ?? browser.browserAction).setIcon({ path: iconPaths })
   }
 }
 


### PR DESCRIPTION
The change addresses a compatibility issue with Firefox by using a fallback mechanism for changing the browser extension icon. Instead of only using `browser.action.setIcon()`, which works in Chrome but not Firefox, the code now tries to use `browser.action` first and falls back to `browser.browserAction` if the former is not available.

This is necessary because Firefox uses the older `browserAction` API while Chrome and other browsers have migrated to the newer `action` API. The change ensures the icon can be properly updated across different browser environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the extension’s icon handling to work consistently across various browser environments. The update introduces a compatibility check that ensures the icon displays reliably, providing a smoother and more robust user experience without altering the overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->