### PR TITLE
Add keyboard navigation for templates and categories using WASD keys

### DIFF
--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -7,7 +7,7 @@
     <meta name="manifest.type" content="browser_action" />
     <link rel="stylesheet" href="~/assets/tailwind.css" />
   </head>
-  <body class="w-[672px] h-[105px]">
+  <body class="w-[672px]">
     <div id="root"></div>
     <script type="module" src="./main.tsx"></script>
   </body>


### PR DESCRIPTION
This change adds WASD keyboard navigation to the popup interface, allowing users to cycle through different templates and categories when generating branch names. Key features include:

1. Added state management for templates, categories, and current selections
2. Implemented keyboard shortcuts:
   - W/S keys to navigate between categories
   - A/D keys to navigate between templates
3. Added visual indicators showing current position (e.g., "Template: 1/5")
4. Improved UI with keyboard shortcut hints
5. Removed fixed height constraint from popup body to accommodate the new navigation UI

The implementation maintains the existing functionality while making it more interactive and user-friendly by allowing quick cycling through different naming options without requiring manual configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the popup with dynamic handling of templates and categories, allowing users to seamlessly switch views.
  - Introduced intuitive keyboard navigation for quick selection and improved interactivity during use.

- **Style**
  - Updated the layout by removing fixed height constraints, resulting in a more flexible and responsive display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->