### PR TITLE
Add installation setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,28 @@ A browser extension that automatically generates standardized git branch names f
 
 ### Chrome/Edge
 
-1. Build the extension for Firefox: `pnpm wxt zip`
+1. Build the extension for Firefox: `pnpm build`
 2. Open Chrome/Edge and navigate to `chrome://extensions` or `edge://extensions`
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select `.output/chrome-mv3` folder
 
 ### Firefox
 
-1. Build the extension for Firefox: `pnpm wxt zip -b firefox`
+1. Build the extension for Firefox: `pnpm zip:firefox`
 2. Open Firefox and navigate to `about:debugging`
 3. Click "This Firefox" in the left sidebar
-4. Click "Load Temporary Add-on..." and select `.output/arborously-x-y-z-firefoz.zip
-6. The extension will be loaded temporarily until you restart Firefox 
+4. Click "Load Temporary Add-on..." and select `.output/arborously-x-y-z-firefox.zip
+5. The extension will be loaded temporarily until you restart Firefox
 
 ### Firefox Nightly
 
 1. In the Firefox Nightly go to `about:config`
 2. Set `xpinstall.signatures.required` to false
-3. Build the extension for Firefox: `pnpm wxt zip -b firefox`
-4. Go to  `about:addons`
+3. Build the extension for Firefox: `pnpm zip:firefox`
+4. Go to `about:addons`
 5. Click the cogwheel icon
-6. Select "Install Add-on From File..."  and select `.output/arborously-x-y-z-firefoz.zip
+6. Select "Install Add-on From File..." and select `.output/arborously-x-y-z-firefox.zip
 7. The extension will persist across restarts
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ A browser extension that automatically generates standardized git branch names f
 
 ### Chrome/Edge
 
-1. Build the extension for Firefox: `pnpm build`
+1. Build the extension for Chrome: `pnpm build`
 2. Open Chrome/Edge and navigate to `chrome://extensions` or `edge://extensions`
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select `.output/chrome-mv3` folder
 
 ### Firefox
 
-1. Build the extension for Firefox: `pnpm zip:firefox`
+1. Bundle the extension for Firefox: `pnpm zip:firefox`
 2. Open Firefox and navigate to `about:debugging`
 3. Click "This Firefox" in the left sidebar
 4. Click "Load Temporary Add-on..." and select `.output/arborously-x-y-z-firefox.zip
@@ -31,7 +31,7 @@ A browser extension that automatically generates standardized git branch names f
 
 1. In the Firefox Nightly go to `about:config`
 2. Set `xpinstall.signatures.required` to false
-3. Build the extension for Firefox: `pnpm zip:firefox`
+3. Bundle the extension for Firefox: `pnpm zip:firefox`
 4. Go to `about:addons`
 5. Click the cogwheel icon
 6. Select "Install Add-on From File..." and select `.output/arborously-x-y-z-firefox.zip

--- a/README.md
+++ b/README.md
@@ -14,18 +14,29 @@ A browser extension that automatically generates standardized git branch names f
 
 ### Chrome/Edge
 
-1. Download the latest release from the [Releases page](https://github.com/yourusername/arborously/releases)
-2. Unzip the file
-3. Open Chrome/Edge and navigate to `chrome://extensions` or `edge://extensions`
-4. Enable "Developer mode"
-5. Click "Load unpacked" and select the unzipped folder
+1. Build the extension for Firefox: `pnpm wxt zip`
+2. Open Chrome/Edge and navigate to `chrome://extensions` or `edge://extensions`
+3. Enable "Developer mode"
+4. Click "Load unpacked" and select `.output/chrome-mv3` folder
 
 ### Firefox
 
-1. Download the latest Firefox release from the [Releases page](https://github.com/yourusername/arborously/releases)
-2. Open Firefox and navigate to `about:addons`
-3. Click the gear icon and select "Install Add-on From File..."
-4. Select the downloaded `.xpi` file
+1. Build the extension for Firefox: `pnpm wxt zip -b firefox`
+2. Open Firefox and navigate to `about:debugging`
+3. Click "This Firefox" in the left sidebar
+4. Click "Load Temporary Add-on..." and select `.output/arborously-x-y-z-firefoz.zip
+6. The extension will be loaded temporarily until you restart Firefox 
+
+### Firefox Nightly
+
+1. In the Firefox Nightly go to `about:config`
+2. Set `xpinstall.signatures.required` to false
+3. Build the extension for Firefox: `pnpm wxt zip -b firefox`
+4. Go to  `about:addons`
+5. Click the cogwheel icon
+6. Select "Install Add-on From File..."  and select `.output/arborously-x-y-z-firefoz.zip
+7. The extension will persist across restarts
+
 
 ## Development
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   manifest: {
     browser_specific_settings: {
       gecko: {
-        id: "arborously@cxodery-royale.com"
+        id: "arborously@codery-royale.com"
       }
     },
     permissions: ["tabs", "storage"],

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -4,6 +4,11 @@ import { defineConfig } from "wxt"
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   manifest: {
+    browser_specific_settings: {
+      gecko: {
+        id: "arborously@cxodery-royale.com"
+      }
+    },
     permissions: ["tabs", "storage"],
     icons: {
       16: "icon/trunk-16.png",


### PR DESCRIPTION
This update significantly improves the setup instructions for the Arborously browser extension across different browsers:

1. Replaced generic download instructions with specific build commands using pnpm and wxt
2. Added detailed instructions for Firefox Nightly, including how to bypass signature requirements
3. Updated Chrome/Edge installation to use the correct output directory (.output/chrome-mv3)
4. Added Firefox temporary installation instructions via about:debugging
5. Added browser_specific_settings in wxt.config.ts with a gecko ID for Firefox Nightly compatibility

The changes make the setup process more accurate and developer-friendly by providing the exact commands and paths needed for each browser environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for the extension on Chrome/Edge, Firefox, and Firefox Nightly to streamline setup across platforms.
- **Chores**
  - Added browser-specific settings for Gecko-based browsers in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->