### PR TITLE
Add GitHub Actions workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Lint
+        run: pnpm lint
+      
+      - name: Type check
+        run: pnpm compile
+      
+      - name: Run tests
+        run: pnpm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Arborously 🌳
+# Arborously 🌳 [![CI](https://github.com/farmisen/arborously/actions/workflows/ci.yml/badge.svg)](https://github.com/farmisen/arborously/actions/workflows/ci.yml)
 
 A browser extension that automatically generates standardized git branch names from ticket information across various ticketing systems.
 


### PR DESCRIPTION
This change adds a new GitHub Actions workflow for continuous integration. The workflow:

1. Creates a CI pipeline that runs on push to main, pull requests to main, and manual triggers
2. Sets up a job that:
   - Uses Ubuntu as the runner
   - Sets up Node.js 22
   - Installs pnpm 9
   - Installs dependencies
   - Runs linting
   - Performs type checking
   - Executes tests

Additionally, a CI status badge has been added to the README.md file to display the current build status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced an automated continuous integration process to validate code quality and testing with each update.
- **Documentation**
	- Updated the homepage with a live continuous integration badge for real-time build status visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->