### PR TITLE
Close popup when opening the options screen

### DIFF
--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -46,7 +46,10 @@ const Icons = () => {
               variant="ghost"
               size="icon"
               className="h-8 w-8"
-              onClick={() => browser.runtime.openOptionsPage()}>
+              onClick={() => {
+                browser.runtime.openOptionsPage();
+                window.close();
+              }}>
               <Settings className="h-4 w-4" />
               <span className="sr-only">Options</span>
             </Button>

--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -47,7 +47,7 @@ const Icons = () => {
               size="icon"
               className="h-8 w-8"
               onClick={() => {
-                browser.runtime.openOptionsPage()
+                void browser.runtime.openOptionsPage()
                 window.close()
               }}>
               <Settings className="h-4 w-4" />

--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -46,8 +46,8 @@ const Icons = () => {
               variant="ghost"
               size="icon"
               className="h-8 w-8"
-              onClick={() => {
-                void browser.runtime.openOptionsPage()
+              onClick={async () => {
+                await browser.runtime.openOptionsPage()
                 window.close()
               }}>
               <Settings className="h-4 w-4" />

--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -47,8 +47,8 @@ const Icons = () => {
               size="icon"
               className="h-8 w-8"
               onClick={() => {
-                browser.runtime.openOptionsPage();
-                window.close();
+                browser.runtime.openOptionsPage()
+                window.close()
               }}>
               <Settings className="h-4 w-4" />
               <span className="sr-only">Options</span>


### PR DESCRIPTION
This change modifies the behavior of the settings button in the popup interface. Previously, clicking the settings button would only open the options page. With this change, the popup window will now automatically close after opening the options page.

The implementation replaces the simple onClick handler with a function that calls both browser.runtime.openOptionsPage() and window.close() to ensure a cleaner user experience by not leaving the popup open when navigating to options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Settings button behavior so that after opening the options page, the popup automatically closes, streamlining the interface and enhancing user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->