### PR TITLE
Add GitHub repository link to popup

### DIFF
--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -10,11 +10,20 @@ import {
 
 const Icons = () => {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-0">
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={async () => {
+                await browser.tabs.create({
+                  url: "https://github.com/farmisen/arborously"
+                })
+                window.close()
+              }}>
               <Github className="h-4 w-4" />
               <span className="sr-only">GitHub Repository</span>
             </Button>


### PR DESCRIPTION
This change adds functionality to the GitHub icon button in the popup interface. When clicked, the button now:

1. Opens a new browser tab to the GitHub repository (https://github.com/farmisen/arborously)
2. Closes the popup window after opening the link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the GitHub button to open the repository in a new browser tab and automatically close the current window, making navigation smoother.
- **Style**
	- Adjusted the icon spacing for a more streamlined and visually appealing layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->