### PR TITLE
Add link to GitHub repository README in help button

### DIFF
--- a/entrypoints/popup/Icons.tsx
+++ b/entrypoints/popup/Icons.tsx
@@ -37,7 +37,16 @@ const Icons = () => {
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={async () => {
+                await browser.tabs.create({
+                  url: "https://github.com/farmisen/arborously/blob/main/README.md"
+                })
+                window.close()
+              }}>
               <HelpCircle className="h-4 w-4" />
               <span className="sr-only">Documentation</span>
             </Button>


### PR DESCRIPTION
Added functionality to the help button in the popup interface to open the project's GitHub README documentation when clicked. The button now:

1. Opens a new browser tab pointing to the Arborously GitHub repository README
2. Closes the popup window after opening the documentation

This change improves user experience by providing direct access to documentation from the extension's popup interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Help button behavior so that clicking it now opens the detailed documentation in a new browser tab, providing users faster access to in-depth guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->