### PR TITLE
Implement title extraction from GitHub issue pages

### DIFF
--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -1,0 +1,57 @@
+import { getCurrentTicketInfoService } from "@/lib/current-ticket-info-service"
+import { sendMessage } from "@/lib/messaging"
+import { getTicketProvidersService } from "@/lib/ticket-providers-service"
+
+const currentTicketInfoService = getCurrentTicketInfoService()
+const ticketProvidersService = getTicketProvidersService()
+
+/**
+ * Content script that extracts ticket information from supported web pages.
+ * Processes the current URL to determine if it's a valid ticket page,
+ * extracts ticket information using the appropriate provider,
+ * and stores/broadcasts the ticket data to other parts of the extension.
+ */
+
+export default defineContentScript({
+  // Set "registration" to runtime so this file isn't listed in manifest
+  registration: "runtime",
+  // Use an empty array for matches to prevent any host_permissions be added
+  //  when using `registration: "runtime"`.
+  matches: [],
+
+  async main() {
+    await processCurrentUrl()
+  }
+})
+
+async function processCurrentUrl() {
+  try {
+    const url = window.location.href
+
+    // Check if the current URL is supported by any of our providers
+    const isValidUrl = await ticketProvidersService.isTicketUrl(url)
+    if (isValidUrl) {
+      // Get the CSS selector for title from the provider
+      const titleSelector = await ticketProvidersService.getTitleSelector(url)
+
+      // Extract the title from the DOM if we have a selector
+      let titleText: string | undefined
+      if (titleSelector) {
+        const titleElement = document.querySelector(titleSelector)
+        titleText = titleElement?.textContent?.trim()
+      }
+
+      // Use the provider to extract ticket info
+      const ticketInfo = await ticketProvidersService.extractTicketInfo(url, titleText)
+
+      // Store the ticket info in the current ticket info service
+      // and notify the background script
+      if (ticketInfo) {
+        await currentTicketInfoService.set(url, ticketInfo)
+        await sendMessage("ticketInfoNotification", ticketInfo)
+      }
+    }
+  } catch (error) {
+    console.error("Error extracting ticket info:", error)
+  }
+}

--- a/entrypoints/options/OptionsPage.tsx
+++ b/entrypoints/options/OptionsPage.tsx
@@ -242,6 +242,7 @@ const OptionsPage = () => {
       return generateBranchName(
         selectedTemplate.template,
         {
+          url: "https://example.com",
           id: previewData.id,
           title: previewData.title,
           category: categoryName

--- a/lib/__tests__/branch-name-generator.test.ts
+++ b/lib/__tests__/branch-name-generator.test.ts
@@ -7,6 +7,7 @@ describe("generator", () => {
   describe("generate", () => {
     it("should use default category when ticket has no category", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket"
       }
@@ -25,6 +26,7 @@ describe("generator", () => {
     })
     it("should replace template variables with corresponding values", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket",
         category: "Feature"
@@ -45,6 +47,7 @@ describe("generator", () => {
 
     it("should handle empty values by replacing with empty strings", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: ""
       }
@@ -64,6 +67,7 @@ describe("generator", () => {
 
     it("should throw an error for missing template fields", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         title: "Test Ticket"
       }
       const username = "testuser"
@@ -77,6 +81,7 @@ describe("generator", () => {
 
     it("should strip out special characters", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Special @ Characters & Spaces",
         category: "Test"
@@ -96,7 +101,7 @@ describe("generator", () => {
     })
 
     it("should work with just the username field", () => {
-      const ticketInfo: TicketInfo = {}
+      const ticketInfo: TicketInfo = { url: "https://example.com" }
       const username = "testuser"
       const urlTemplate = "{username}/static-path"
       const defaultCategory = "test"
@@ -113,6 +118,7 @@ describe("generator", () => {
 
     it("it should work without the username field", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket With Spaces",
         category: "Feature"
@@ -133,6 +139,7 @@ describe("generator", () => {
 
     it("should respect custom replacement character option", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket With Spaces",
         category: "Feature"
@@ -158,6 +165,7 @@ describe("generator", () => {
 
     it("should respect uppercase option", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket",
         category: "Feature"
@@ -183,6 +191,7 @@ describe("generator", () => {
 
     it("should use default options when none are provided", () => {
       const ticketInfo: TicketInfo = {
+        url: "https://example.com",
         id: "123",
         title: "Test Ticket",
         category: "Feature"

--- a/lib/current-ticket-info-service.ts
+++ b/lib/current-ticket-info-service.ts
@@ -1,0 +1,32 @@
+import { defineProxyService } from "@webext-core/proxy-service"
+
+import { type TicketInfo } from "./types"
+
+const ticketInfos = new Map<string, TicketInfo>()
+
+export type CurrentTicketInfoService = {
+  set(url: string, ticketInfo: TicketInfo): void
+  get(url: string): TicketInfo | undefined
+  reset(): void
+}
+
+const createCurrentTicketInfoService = (): CurrentTicketInfoService => {
+  const service: CurrentTicketInfoService = {
+    set(url: string, ticketInfo: TicketInfo): void {
+      ticketInfos.set(url, ticketInfo)
+    },
+
+    get(url: string): TicketInfo | undefined {
+      return ticketInfos.get(url)
+    },
+
+    reset() {
+      ticketInfos.clear()
+    }
+  }
+
+  return service
+}
+
+export const [registerCurrentTicketInfoService, getCurrentTicketInfoService] =
+  defineProxyService("current-ticket-info-service", createCurrentTicketInfoService)

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -1,0 +1,10 @@
+import { defineExtensionMessaging } from "@webext-core/messaging"
+
+import { type TicketInfo } from "./types"
+
+interface ProtocolMap {
+  ticketInfoNotification(ticketInfo: TicketInfo): void
+}
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+export const { sendMessage, onMessage } = defineExtensionMessaging<ProtocolMap>()

--- a/lib/providers/__tests__/github-issues-provider.test.ts
+++ b/lib/providers/__tests__/github-issues-provider.test.ts
@@ -5,45 +5,46 @@ import { GithubIssuesProvider } from "../github-issues-provider"
 describe("GithubIssuesProvider", () => {
   const provider = new GithubIssuesProvider()
 
-  describe("isSupported", () => {
+  describe("isValidUrl", () => {
     it("should return true for valid GitHub issue URLs", () => {
-      expect(provider.isSupported("https://github.com/facebook/react/issues/123")).toBe(
+      expect(provider.isTicketUrl("https://github.com/facebook/react/issues/123")).toBe(
         true
       )
       expect(
-        provider.isSupported("https://github.com/microsoft/typescript/issues/45678")
+        provider.isTicketUrl("https://github.com/microsoft/typescript/issues/45678")
       ).toBe(true)
-      expect(provider.isSupported("http://github.com/owner/repo/issues/1")).toBe(true)
-      expect(provider.isSupported("https://www.github.com/owner/repo/issues/999")).toBe(
+      expect(provider.isTicketUrl("http://github.com/owner/repo/issues/1")).toBe(true)
+      expect(provider.isTicketUrl("https://www.github.com/owner/repo/issues/999")).toBe(
         true
       )
     })
 
     it("should return false for invalid GitHub URLs", () => {
-      expect(provider.isSupported("https://github.com/facebook/react")).toBe(false)
-      expect(provider.isSupported("https://github.com/facebook/react/tree/main")).toBe(
+      expect(provider.isTicketUrl("https://github.com/facebook/react")).toBe(false)
+      expect(provider.isTicketUrl("https://github.com/facebook/react/tree/main")).toBe(
         false
       )
       expect(
-        provider.isSupported("https://github.com/facebook/react/blob/main/README.md")
+        provider.isTicketUrl("https://github.com/facebook/react/blob/main/README.md")
       ).toBe(false)
-      expect(provider.isSupported("https://github.com/facebook")).toBe(false)
-      expect(provider.isSupported("https://github.com")).toBe(false)
-      expect(provider.isSupported("https://gitlab.com/owner/repo/issues/123")).toBe(
+      expect(provider.isTicketUrl("https://github.com/facebook")).toBe(false)
+      expect(provider.isTicketUrl("https://github.com")).toBe(false)
+      expect(provider.isTicketUrl("https://gitlab.com/owner/repo/issues/123")).toBe(
         false
       )
-      expect(provider.isSupported("https://github.com/facebook/react/pull/123")).toBe(
+      expect(provider.isTicketUrl("https://github.com/facebook/react/pull/123")).toBe(
         false
       )
     })
   })
 
-  describe("parseUrl", () => {
-    it("should correctly parse GitHub issue URLs", () => {
+  describe("extractTicketInfo", () => {
+    it("should correctly extract info from GitHub issue URLs", () => {
       const url = "https://github.com/facebook/react/issues/123"
-      const result = provider.parseUrl(url)
+      const result = provider.extractTicketInfo(url)
 
       expect(result).toEqual({
+        url,
         id: "123",
         metadata: {
           owner: "facebook",
@@ -53,12 +54,30 @@ describe("GithubIssuesProvider", () => {
       })
     })
 
+    it("should include title when titleText is provided", () => {
+      const url = "https://github.com/facebook/react/issues/123"
+      const titleText = "Test Issue Title"
+
+      const result = provider.extractTicketInfo(url, titleText)
+
+      expect(result).toEqual({
+        url,
+        id: "123",
+        title: "Test Issue Title",
+        metadata: {
+          owner: "facebook",
+          repo: "react",
+          type: "issues"
+        }
+      })
+    })
+
     it("should throw an error for invalid GitHub URLs", () => {
-      expect(() => provider.parseUrl("https://github.com/facebook/react")).toThrow(
-        "Not a valid GitHub Issues URL"
-      )
       expect(() =>
-        provider.parseUrl("https://gitlab.com/owner/repo/issues/123")
+        provider.extractTicketInfo("https://github.com/facebook/react")
+      ).toThrow("Not a valid GitHub Issues URL")
+      expect(() =>
+        provider.extractTicketInfo("https://gitlab.com/owner/repo/issues/123")
       ).toThrow("Not a valid GitHub Issues URL")
     })
   })

--- a/lib/providers/__tests__/trello-provider.test.ts
+++ b/lib/providers/__tests__/trello-provider.test.ts
@@ -5,45 +5,47 @@ import { TrelloProvider } from "../trello-provider"
 describe("TrelloProvider", () => {
   const provider = new TrelloProvider()
 
-  describe("isSupported", () => {
+  describe("isValidUrl", () => {
     it("should return true for valid Trello card URLs", () => {
-      expect(provider.isSupported("https://trello.com/c/abcd1234")).toBe(true)
-      expect(provider.isSupported("https://trello.com/c/abcd1234/123-card-title")).toBe(
+      expect(provider.isTicketUrl("https://trello.com/c/abcd1234")).toBe(true)
+      expect(provider.isTicketUrl("https://trello.com/c/abcd1234/123-card-title")).toBe(
         true
       )
-      expect(provider.isSupported("http://trello.com/c/XYZ789")).toBe(true)
+      expect(provider.isTicketUrl("http://trello.com/c/XYZ789")).toBe(true)
       expect(
-        provider.isSupported("https://www.trello.com/c/abcd1234/123-my-card-title")
+        provider.isTicketUrl("https://www.trello.com/c/abcd1234/123-my-card-title")
       ).toBe(true)
     })
 
     it("should return false for invalid Trello URLs", () => {
-      expect(provider.isSupported("https://trello.com/b/abcd1234/board-name")).toBe(
+      expect(provider.isTicketUrl("https://trello.com/b/abcd1234/board-name")).toBe(
         false
       )
-      expect(provider.isSupported("https://trello.com/u/username")).toBe(false)
-      expect(provider.isSupported("https://trello.com")).toBe(false)
-      expect(provider.isSupported("https://asana.com/123")).toBe(false)
+      expect(provider.isTicketUrl("https://trello.com/u/username")).toBe(false)
+      expect(provider.isTicketUrl("https://trello.com")).toBe(false)
+      expect(provider.isTicketUrl("https://asana.com/123")).toBe(false)
     })
   })
 
-  describe("parseUrl", () => {
-    it("should correctly parse Trello card URLs with minimal info", () => {
+  describe("extractTicketInfo", () => {
+    it("should correctly extract info from Trello card URLs with minimal info", () => {
       const url = "https://trello.com/c/abcd1234"
-      const result = provider.parseUrl(url)
+      const result = provider.extractTicketInfo(url)
 
       expect(result).toEqual({
+        url,
         id: undefined,
         title: undefined,
         metadata: { uuid: "abcd1234" }
       })
     })
 
-    it("should correctly parse Trello card URLs with card number and title", () => {
+    it("should correctly extract info from Trello card URLs with card number and title", () => {
       const url = "https://trello.com/c/abcd1234/123-card-title"
-      const result = provider.parseUrl(url)
+      const result = provider.extractTicketInfo(url)
 
       expect(result).toEqual({
+        url,
         id: "123",
         title: "card title",
         metadata: { uuid: "abcd1234" }
@@ -52,9 +54,10 @@ describe("TrelloProvider", () => {
 
     it("should correctly handle multi-word card titles", () => {
       const url = "https://trello.com/c/abcd1234/123-implement-new-feature-for-project"
-      const result = provider.parseUrl(url)
+      const result = provider.extractTicketInfo(url)
 
       expect(result).toEqual({
+        url,
         id: "123",
         title: "implement new feature for project",
         metadata: { uuid: "abcd1234" }
@@ -63,9 +66,9 @@ describe("TrelloProvider", () => {
 
     it("should throw an error for invalid Trello URLs", () => {
       expect(() =>
-        provider.parseUrl("https://trello.com/b/abcd1234/board-name")
+        provider.extractTicketInfo("https://trello.com/b/abcd1234/board-name")
       ).toThrow("Not a valid Trello card URL")
-      expect(() => provider.parseUrl("https://asana.com/123")).toThrow(
+      expect(() => provider.extractTicketInfo("https://asana.com/123")).toThrow(
         "Not a valid Trello card URL"
       )
     })

--- a/lib/providers/github-issues-provider.ts
+++ b/lib/providers/github-issues-provider.ts
@@ -1,23 +1,21 @@
 import { type TicketProvider } from "@/lib/ticket-providers-service"
 import { type TicketInfo } from "@/lib/types"
 
-// This provider does not extract the title from the URL
-// and should be updated to parse the title from the page
-
 export class GithubIssuesProvider implements TicketProvider {
-  name = "github-issues"
+  titleSelector = ".markdown-title"
 
-  // Matches GitHub Issues URLs
-  // Examples:
-  // - https://github.com/owner/repo/issues/123
   private readonly GITHUB_ISSUES_REGEX =
     /^https?:\/\/(?:www\.)?github\.com\/([^\/]+)\/([^\/]+)\/(issues)\/(\d+)/
 
-  isSupported(url: string): boolean {
+  static getMatchPatterns(): string[] {
+    return ["https://github.com/*/*/issues/*", "https://www.github.com/*/*/issues/*"]
+  }
+
+  isTicketUrl(url: string): boolean {
     return this.GITHUB_ISSUES_REGEX.test(url)
   }
 
-  parseUrl(url: string): TicketInfo {
+  extractTicketInfo(url: string, titleText?: string): TicketInfo {
     const match = url.match(this.GITHUB_ISSUES_REGEX)
 
     if (!match) {
@@ -29,7 +27,8 @@ export class GithubIssuesProvider implements TicketProvider {
     const type = match[3]
     const issueId = match[4]
 
-    return {
+    const baseInfo: TicketInfo = {
+      url,
       id: issueId,
       metadata: {
         owner,
@@ -37,5 +36,14 @@ export class GithubIssuesProvider implements TicketProvider {
         type
       }
     }
+
+    if (titleText) {
+      return {
+        ...baseInfo,
+        title: titleText
+      }
+    }
+
+    return baseInfo
   }
 }

--- a/lib/providers/trello-provider.ts
+++ b/lib/providers/trello-provider.ts
@@ -2,18 +2,18 @@ import { type TicketProvider } from "@/lib/ticket-providers-service"
 import { type TicketInfo } from "@/lib/types"
 
 export class TrelloProvider implements TicketProvider {
-  name = "trello"
-
-  // Matches Trello card URLs
-  // Example: https://trello.com/c/abcd1234/123-card-title
   private readonly TRELLO_CARD_REGEX =
     /^https?:\/\/(?:www\.)?trello\.com\/c\/([a-zA-Z0-9]+)(?:\/(\d+)(?:-([^/]+))?)?/
 
-  isSupported(url: string): boolean {
+  static getMatchPatterns(): string[] {
+    return ["https://trello.com/*/*/*", "https://www.trello.com/*/*/*"]
+  }
+
+  isTicketUrl(url: string): boolean {
     return this.TRELLO_CARD_REGEX.test(url)
   }
 
-  parseUrl(url: string): TicketInfo {
+  extractTicketInfo(url: string, _titleText?: string): TicketInfo {
     const match = url.match(this.TRELLO_CARD_REGEX)
 
     if (!match) {
@@ -21,6 +21,7 @@ export class TrelloProvider implements TicketProvider {
     }
 
     return {
+      url,
       id: match[2],
       title: match[3] ? match[3].replace(/-/g, " ") : undefined,
       metadata: { uuid: match[1] }

--- a/lib/ticket-providers-service.ts
+++ b/lib/ticket-providers-service.ts
@@ -5,15 +5,21 @@ import { type TicketInfo } from "@/lib/types"
 
 // Base provider interface that platform-specific parsers must implement
 export interface TicketProvider {
-  name: string
-  isSupported(url: string): boolean
-  parseUrl(url: string): TicketInfo
+  isTicketUrl(url: string): boolean
+  titleSelector?: string
+  extractTicketInfo(url: string, titleText?: string): TicketInfo
+}
+
+// Interface for the static methods on provider classes
+export interface TicketProviderStatic {
+  getMatchPatterns(): string[]
 }
 
 export type TicketProvidersService = {
   registerProvider(provider: TicketProvider): void
-  isSupported(url: string): boolean
-  parseUrl(url: string): TicketInfo
+  isTicketUrl(url: string): boolean
+  extractTicketInfo(url: string, titleText?: string): TicketInfo
+  getTitleSelector(url: string): string | undefined
   getProviders(): TicketProvider[]
 }
 
@@ -29,18 +35,23 @@ const createTicketProvidersService = (): TicketProvidersService => {
       return [...providers]
     },
 
-    isSupported(url: string) {
-      return providers.some((provider) => provider.isSupported(url))
+    isTicketUrl(url: string) {
+      return providers.some((provider) => provider.isTicketUrl(url))
     },
 
-    parseUrl(url: string): TicketInfo {
-      const provider = providers.find((provider) => provider.isSupported(url))
+    getTitleSelector(url: string): string | undefined {
+      const provider = providers.find((provider) => provider.isTicketUrl(url))
+      return provider?.titleSelector
+    },
+
+    extractTicketInfo(url: string, titleText?: string): TicketInfo {
+      const provider = providers.find((provider) => provider.isTicketUrl(url))
 
       if (!provider) {
         throw new Error(`No provider found for URL: ${url}`)
       }
 
-      return provider.parseUrl(url)
+      return provider.extractTicketInfo(url, titleText)
     }
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,5 @@
 export type TicketInfo = {
+  url: string
   id?: string
   title?: string
   category?: string

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@webext-core/messaging": "^2.2.0",
     "@webext-core/proxy-service": "^1.2.1",
     "@webext-core/storage": "^1.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@webext-core/messaging':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@webext-core/proxy-service':
         specifier: ^1.2.1
         version: 1.2.1(@webext-core/messaging@2.2.0)(webextension-polyfill@0.12.0)

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,9 @@
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from "wxt"
 
+import { GithubIssuesProvider } from "./lib/providers/github-issues-provider"
+import { TrelloProvider } from "./lib/providers/trello-provider"
+
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   manifest: {
@@ -16,7 +19,12 @@ export default defineConfig({
       48: "icon/trunk-arborously-48.png",
       96: "icon/trunk-arborously-96.png",
       128: "icon/trunk-arborously-128.png"
-    }
+    },
+    host_permissions: [
+      "http://localhost/*",
+      ...GithubIssuesProvider.getMatchPatterns(),
+      ...TrelloProvider.getMatchPatterns()
+    ]
   },
   vite: () => ({
     plugins: [tailwindcss()],


### PR DESCRIPTION
This change adds the ability to extract ticket titles directly from the DOM and applies it to Github issue pages. The implementation includes several significant architectural improvements:

1. Created a new content script system that extracts ticket information from the DOM
2. Added a new CurrentTicketInfoService to store and manage ticket information
3. Refactored the TicketProvidersService API with more descriptive method names:
   - isSupported → isTicketUrl
   - parseUrl → extractTicketInfo

4. Enhanced the TicketInfo type to include the URL of the ticket
5. Implemented a messaging system between content scripts and background script
6. Added host permissions for supported ticket providers
7. Added title selectors to providers to extract titles from the DOM

The changes improve the user experience by automatically extracting and displaying ticket titles, making branch names more descriptive and contextual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced ticket information extraction with real-time notifications and dynamic icon updates based on valid URLs.
  - Introduced a new content script for extracting ticket information from supported web pages.
  - Added a new property `url` to the `TicketInfo` type for improved structure.
- **Refactor**
  - Streamlined background processing and pop-up workflows, improving URL validation and error handling.
  - Updated the ticket provider interface to focus on URL validation and information extraction.
- **Tests**
  - Updated test cases to ensure accurate ticket verification and information extraction across different ticket providers, now including the `url` property in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->