### PR TITLE
Update readme logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Arborously 🌳 [![CI](https://github.com/farmisen/arborously/actions/workflows/ci.yml/badge.svg)](https://github.com/farmisen/arborously/actions/workflows/ci.yml)
+# ![logo](./public/icon/tree-arborously-24.png) Arborously [![CI](https://github.com/farmisen/arborously/actions/workflows/ci.yml/badge.svg)](https://github.com/farmisen/arborously/actions/workflows/ci.yml)
 
 A browser extension that automatically generates standardized git branch names from ticket information across various ticketing systems.
 


### PR DESCRIPTION
Changed the way the logo is displayed in the README file. Instead of using a text emoji (🌳), the update replaces it with an actual image logo from the project's public directory using Markdown image syntax. The image path points to "./public/icon/tree-arborously-24.png".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project header to feature a visually appealing image logo. The project title remains intact, and the continuous integration badge is still displayed, enhancing the overall visual presentation of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->