### PR TITLE
Add GitHub Action for publishing and releasing extension

### DIFF
--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -1,0 +1,103 @@
+name: Publish & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type (major/minor/patch)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  publish_and_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Bump version in package.json
+        id: bump-version
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+          
+          # Calculate new version
+          if [[ "${{ github.event.inputs.bump_type }}" == "patch" ]]; then
+            NEW_VERSION=$(node -p "const [major, minor, patch] = '${CURRENT_VERSION}'.split('.'); \`\${major}.\${minor}.\${Number(patch) + 1}\`")
+          elif [[ "${{ github.event.inputs.bump_type }}" == "minor" ]]; then
+            NEW_VERSION=$(node -p "const [major, minor, patch] = '${CURRENT_VERSION}'.split('.'); \`\${major}.\${Number(minor) + 1}.0\`")
+          elif [[ "${{ github.event.inputs.bump_type }}" == "major" ]]; then
+            NEW_VERSION=$(node -p "const [major, minor, patch] = '${CURRENT_VERSION}'.split('.'); \`\${Number(major) + 1}.0.0\`")
+          fi
+          
+          echo "New version: $NEW_VERSION"
+          
+          # Update package.json
+          node -e "const pkg = require('./package.json'); pkg.version = '${NEW_VERSION}'; fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n')"
+          
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Commit version changes
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'github-actions@github.com'
+          git add package.json
+          git commit -m "Release v${{ steps.bump-version.outputs.new_version }}"
+          git tag "v${{ steps.bump-version.outputs.new_version }}"
+          git push --atomic origin HEAD:${GITHUB_REF#refs/heads/} "v${{ steps.bump-version.outputs.new_version }}"
+
+      - name: Build Chrome extension
+        run: pnpm zip
+
+      - name: Build Firefox extension
+        run: pnpm zip:firefox
+
+      - name: Upload Chrome extension
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .output/arborously-${{ steps.bump-version.outputs.new_version }}-chrome.zip
+          asset_name: arborously-${{ steps.bump-version.outputs.new_version }}-chrome.zip
+          tag: "v${{ steps.bump-version.outputs.new_version }}"
+          overwrite: true
+
+      - name: Upload Firefox extension
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .output/arborously-${{ steps.bump-version.outputs.new_version }}-firefox.zip
+          asset_name: arborously-${{ steps.bump-version.outputs.new_version }}-firefox.zip
+          tag: "v${{ steps.bump-version.outputs.new_version }}"
+          overwrite: true
+
+      - name: Create Release
+        uses: elgohr/Github-Release-Action@v5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "v${{ steps.bump-version.outputs.new_version }}"
+          tag: "v${{ steps.bump-version.outputs.new_version }}"

--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -57,7 +57,7 @@ jobs:
           echo "New version: $NEW_VERSION"
           
           # Update package.json
-          node -e "const pkg = require('./package.json'); pkg.version = '${NEW_VERSION}'; fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n')"
+          node -e "const fs = require('fs'); const pkg = require('./package.json'); pkg.version = '${NEW_VERSION}'; fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n')"
           
           echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -12,30 +12,43 @@ A browser extension that automatically generates standardized git branch names f
 
 ## Installation
 
+### Easy Installation (Recommended)
+
 ### Chrome/Edge
 
-1. Build the extension for Chrome: `pnpm build`
+1. Download the latest Chrome release from [GitHub Releases](https://github.com/farmisen/arborously/releases)
 2. Open Chrome/Edge and navigate to `chrome://extensions` or `edge://extensions`
 3. Enable "Developer mode"
-4. Click "Load unpacked" and select `.output/chrome-mv3` folder
+4. Drag and drop the downloaded `arborously-x.y.z-chrome.zip` file onto the extensions page
 
 ### Firefox
 
-1. Bundle the extension for Firefox: `pnpm zip:firefox`
+1. Download the latest Firefox release from [GitHub Releases](https://github.com/farmisen/arborously/releases)
 2. Open Firefox and navigate to `about:debugging`
 3. Click "This Firefox" in the left sidebar
-4. Click "Load Temporary Add-on..." and select `.output/arborously-x-y-z-firefox.zip
+4. Click "Load Temporary Add-on..." and select the downloaded `arborously-x.y.z-firefox.zip` file
 5. The extension will be loaded temporarily until you restart Firefox
 
 ### Firefox Nightly
 
-1. In the Firefox Nightly go to `about:config`
+1. In Firefox Nightly go to `about:config`
 2. Set `xpinstall.signatures.required` to false
-3. Bundle the extension for Firefox: `pnpm zip:firefox`
+3. Download the latest Firefox release from [GitHub Releases](https://github.com/farmisen/arborously/releases)
 4. Go to `about:addons`
 5. Click the cogwheel icon
-6. Select "Install Add-on From File..." and select `.output/arborously-x-y-z-firefox.zip
+6. Select "Install Add-on From File..." and select the downloaded `arborously-x.y.z-firefox.zip` file
 7. The extension will persist across restarts
+
+### Manual Build (For Development)
+
+If you prefer to build the extension yourself, please see the [Development](#development) section below.
+
+## Usage
+
+1. Navigate to a Trello card
+2. Click on the Arborously extension icon in your browser toolbar
+3. Select a template and tag for your branch
+4. Click "Copy to Clipboard" to copy the generated branch name
 
 ## Development
 
@@ -78,13 +91,6 @@ pnpm compile
 # Create distributable zip
 pnpm zip
 ```
-
-## Usage
-
-1. Navigate to a Trello card
-2. Click on the Arborously extension icon in your browser toolbar
-3. Select a template and tag for your branch
-4. Click "Copy to Clipboard" to copy the generated branch name
 
 ## Contributing
 


### PR DESCRIPTION
This change adds a new GitHub Actions workflow for automating the publishing and releasing process of the browser extension. The key components include:

1. A new GitHub workflow file (`publish_and_release.yml`) that:
 - Can be manually triggered with a version bump type (major/minor/patch)
 - Automatically calculates the new version number
 - Updates package.json with the new version
 - Commits and tags the changes
 - Builds both Chrome and Firefox extensions
 - Creates a GitHub release with the extension files attached

2. Updated README.md with:
 - New "Easy Installation" section recommending users download pre-built extensions from GitHub Releases
 - Reorganized installation instructions to prioritize the download method
 - Moved the "Usage" section before "Development" to improve document flow

These changes streamline the release process and make it easier for users to install the extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated release workflow that streamlines version updates, builds, and distribution.
- **Documentation**
	- Updated installation instructions for the browser extension, now guiding users to download the latest release for Chrome/Edge and Firefox.
	- Added clear steps for manual builds, alongside repositioned usage guidance for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->