### PR TITLE
Strip query parameters from Trello card URLs

### DIFF
--- a/lib/providers/__tests__/trello-provider.test.ts
+++ b/lib/providers/__tests__/trello-provider.test.ts
@@ -15,6 +15,9 @@ describe("TrelloProvider", () => {
       expect(
         provider.isTicketUrl("https://www.trello.com/c/abcd1234/123-my-card-title")
       ).toBe(true)
+      expect(
+        provider.isTicketUrl("https://trello.com/c/abcd1234/123-card-title?param=value")
+      ).toBe(true)
     })
 
     it("should return false for invalid Trello URLs", () => {
@@ -60,6 +63,19 @@ describe("TrelloProvider", () => {
         url,
         id: "123",
         title: "implement new feature for project",
+        metadata: { uuid: "abcd1234" }
+      })
+    })
+
+    it("should strip query parameters from card titles", () => {
+      const url =
+        "https://trello.com/c/abcd1234/123-implement-feature?param1=value1&param2=value2"
+      const result = provider.extractTicketInfo(url)
+
+      expect(result).toEqual({
+        url,
+        id: "123",
+        title: "implement feature",
         metadata: { uuid: "abcd1234" }
       })
     })

--- a/lib/providers/trello-provider.ts
+++ b/lib/providers/trello-provider.ts
@@ -20,10 +20,13 @@ export class TrelloProvider implements TicketProvider {
       throw new Error("Not a valid Trello card URL")
     }
 
+    // Strip query parameters from title if present
+    const cleanTitle = match[3] ? match[3].split("?")[0].replace(/-/g, " ") : undefined
+
     return {
       url,
       id: match[2],
-      title: match[3] ? match[3].replace(/-/g, " ") : undefined,
+      title: cleanTitle,
       metadata: { uuid: match[1] }
     }
   }


### PR DESCRIPTION
This change improves the handling of Trello card URLs by filtering out query parameters from the card title. 

The main changes adds  support for Trello URLs that contain query parameters by modifying the `extractTicketInfo` method to strip query parameters from the card title

This ensures that branch names and other references derived from Trello card URLs will be cleaner and more consistent, regardless of whether the URL contains query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of Trello card URLs so that extraneous query parameters are removed from displayed card titles. This ensures that card titles appear clean and accurate when interacting with Trello links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->