### PR TITLE
Add support for extracting Trello card titles from page content

### DIFF
--- a/lib/providers/__tests__/trello-provider.test.ts
+++ b/lib/providers/__tests__/trello-provider.test.ts
@@ -88,5 +88,18 @@ describe("TrelloProvider", () => {
         "Not a valid Trello card URL"
       )
     })
+
+    it("should use the provided HTML title when available", () => {
+      const url = "https://trello.com/c/abcd1234/123-card-title-from-url"
+      const htmlTitle = "🇷🇺 Он должен обрабатывать нелатинские шрифты"
+      const result = provider.extractTicketInfo(url, htmlTitle)
+
+      expect(result).toEqual({
+        url,
+        id: "123",
+        title: htmlTitle,
+        metadata: { uuid: "abcd1234" }
+      })
+    })
   })
 })

--- a/lib/providers/trello-provider.ts
+++ b/lib/providers/trello-provider.ts
@@ -4,6 +4,8 @@ import { type TicketInfo } from "@/lib/types"
 export class TrelloProvider implements TicketProvider {
   private readonly TRELLO_CARD_REGEX =
     /^https?:\/\/(?:www\.)?trello\.com\/c\/([a-zA-Z0-9]+)(?:\/(\d+)(?:-([^/]+))?)?/
+  
+  titleSelector = "#card-back-name"
 
   static getMatchPatterns(): string[] {
     return ["https://trello.com/*/*/*", "https://www.trello.com/*/*/*"]
@@ -13,20 +15,20 @@ export class TrelloProvider implements TicketProvider {
     return this.TRELLO_CARD_REGEX.test(url)
   }
 
-  extractTicketInfo(url: string, _titleText?: string): TicketInfo {
+  extractTicketInfo(url: string, titleText?: string): TicketInfo {
     const match = url.match(this.TRELLO_CARD_REGEX)
 
     if (!match) {
       throw new Error("Not a valid Trello card URL")
     }
 
-    // Strip query parameters from title if present
-    const cleanTitle = match[3] ? match[3].split("?")[0].replace(/-/g, " ") : undefined
+    // Use the title from the HTML element if available, otherwise fall back to URL parsing
+    const title = titleText || (match[3] ? match[3].split("?")[0].replace(/-/g, " ") : undefined)
 
     return {
       url,
       id: match[2],
-      title: cleanTitle,
+      title,
       metadata: { uuid: match[1] }
     }
   }

--- a/lib/providers/trello-provider.ts
+++ b/lib/providers/trello-provider.ts
@@ -4,7 +4,7 @@ import { type TicketInfo } from "@/lib/types"
 export class TrelloProvider implements TicketProvider {
   private readonly TRELLO_CARD_REGEX =
     /^https?:\/\/(?:www\.)?trello\.com\/c\/([a-zA-Z0-9]+)(?:\/(\d+)(?:-([^/]+))?)?/
-  
+
   titleSelector = "#card-back-name"
 
   static getMatchPatterns(): string[] {
@@ -23,7 +23,8 @@ export class TrelloProvider implements TicketProvider {
     }
 
     // Use the title from the HTML element if available, otherwise fall back to URL parsing
-    const title = titleText || (match[3] ? match[3].split("?")[0].replace(/-/g, " ") : undefined)
+    const title =
+      titleText ?? (match[3] ? match[3].split("?")[0].replace(/-/g, " ") : undefined)
 
     return {
       url,


### PR DESCRIPTION
This change improves the Trello provider to extract card titles directly from the HTML page content rather than relying solely on parsing the URL. Key changes include:

1. Added a `titleSelector` property to identify the HTML element containing the card title (#card-back-name)
2. Modified the `extractTicketInfo` method to prioritize the title from the HTML element when available
3. Added a test case to verify that the provider correctly handles HTML titles, including non-Latin characters

This enhancement ensures more accurate ticket titles, especially for cards with special characters or non-Latin scripts that wouldn't be properly represented in the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced ticket detail processing to reliably use a provided display title when available, ensuring more accurate information presentation.
- **Tests**
  - Added additional test coverage to validate the improved title handling for ticket details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->