### PR TITLE
[ROY-14] Copy the generated value on enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A browser extension that automatically generates standardized git branch names f
   - Toggle between branch name, PR title, and ticket URL modes
   - Keyboard shortcuts for efficient workflow
   - Maintains state between uses
+  - Press Enter to quickly copy the current value
 
 - **Cross-browser Support**:
   - Works seamlessly in Chrome, Firefox, and Edge
@@ -85,10 +86,13 @@ If you prefer to build the extension yourself, please see the [Development](#dev
   - **PR Title**: Properly formatted pull request title 
   - **Ticket URL**: Clean URL for the current ticket
 
-- **Category Selection** (in Branch Name mode):
-  - Use `A` key to cycle to the previous category
-  - Use `D` key to cycle to the next category
-  - The extension remembers your last selected category
+- **Keyboard Shortcuts**:
+  - **Category Selection** (in Branch Name mode):
+    - Use `A` key to cycle to the previous category
+    - Use `D` key to cycle to the next category
+  - Use `Space` key to toggle between modes
+  - Use `Enter` key to copy the current content to clipboard
+  - The extension remembers your last selected category and mode
 
 - **Template Customization**:
   - Go to the extension options page (right-click the extension icon and select "Options")

--- a/entrypoints/popup/Popup.tsx
+++ b/entrypoints/popup/Popup.tsx
@@ -16,6 +16,12 @@ const Popup = () => {
   const [description, setDescription] = useState("")
   const [copyDisabled, setCopyDisabled] = useState(true)
 
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => window.close(), 2000)
+  }
+
   const [
     {
       branchName,
@@ -52,6 +58,12 @@ const Popup = () => {
         setCopied(false)
         // Prevent page scrolling
         e.preventDefault()
+      } else if (e.key === "Enter" && !copyDisabled) {
+        // Copy the content when Enter is pressed and content is available
+        copyToClipboard().catch((error) =>
+          console.error("Error copying to clipboard:", error)
+        )
+        e.preventDefault()
       }
     }
 
@@ -59,13 +71,7 @@ const Popup = () => {
     return () => {
       window.removeEventListener("keydown", handleKeyDown)
     }
-  }, [changeCategory, changeMode, mode])
-
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(content)
-    setCopied(true)
-    setTimeout(() => window.close(), 2000)
-  }
+  }, [changeCategory, changeMode, mode, copyDisabled, copyToClipboard])
 
   useEffect(() => {
     if (mode === PopupMode.BRANCH_NAME) {
@@ -127,7 +133,7 @@ const Popup = () => {
 
           {/* navigation */}
           <div className="text-sm text-muted-foreground">
-            <div className="flex justify-start gap-2">
+            <div className="flex justify-start gap-2 flex-wrap">
               <div className="flex gap-2">
                 <div>
                   Mode:{" "}
@@ -152,6 +158,12 @@ const Popup = () => {
                   </div>
                 </div>
               )}
+              <div className="flex gap-2">
+                <div>Copy:</div>
+                <div>
+                  (<kbd className="px-1 bg-muted rounded">enter</kbd>)
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This change adds the ability to press Enter to copy the currently generated value to the clipboard, improving user experience by providing a faster way to copy content. 

This enhancement complements the existing keyboard shortcuts (A/D for category selection, Space for mode toggling) with a natural Enter key action for copying, making the extension more keyboard-friendly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for copying the current value using the Enter key shortcut when enabled.
  - Updated the navigation UI to display a "Copy:" label with an Enter key hint for improved usability.

- **Documentation**
  - Expanded and reorganized the README to clarify all available keyboard shortcuts and their usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->